### PR TITLE
Additional detail in boilerplate

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,13 +4,10 @@ use std::convert::TryFrom;
 
 const ONE_MINUTE_TTL: i32 = 60;
 const NO_CACHE_TTL: i32 = -1;
-const VALID_METHODS: [Method; 6] = [
+const VALID_METHODS: [Method; 3] = [
     Method::HEAD,
     Method::GET,
-    Method::POST,
-    Method::PUT,
-    Method::PATCH,
-    Method::DELETE,
+    Method::POST
 ];
 
 /// Handle the downstream request from the client.

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn handle_request(mut req: Request<Body>) -> Result<Response<Body>, Error> {
     if !(VALID_METHODS.contains(req.method())) {
         return Ok(Response::builder()
             .status(StatusCode::METHOD_NOT_ALLOWED)
-            .body(Body::try_from("Only GET and HEAD requests are allowed")?)?);
+            .body(Body::try_from("This method is not allowed")?)?);
     }
 
     // Pattern match on the request method and path.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use fastly::http::{Method, StatusCode};
+use fastly::http::{Method, StatusCode, HeaderValue};
 use fastly::{downstream_request, Body, Error, Request, RequestExt, Response, ResponseExt};
 use std::convert::TryFrom;
 
@@ -11,34 +11,58 @@ const NO_CACHE_TTL: i32 = -1;
 /// be used to route based on the request properties (such as method or path),
 /// send the request to a backend, make completely new requests and/or generate
 /// synthetic responses.
-fn handle_request(req: Request<Body>) -> Result<Response<Body>, Error> {
+fn handle_request(mut req: Request<Body>) -> Result<Response<Body>, Error> {
+
+    // Make any desired changes to the client request
+    req.headers_mut().insert("Host", HeaderValue::from_static("example.com"));
+
     // Pattern match on the request method and path.
     match (req.method(), req.uri().path()) {
-        // If request is `GET /`.
+
+        // If request method is not GET or HEAD, error
+        (method, _) if !(vec![Method::HEAD, Method::GET].contains(method)) => Ok(
+            Response::builder()
+            .status(StatusCode::METHOD_NOT_ALLOWED)
+            .body(Body::try_from("The page you requested could not be found")?)?
+        ),
+
+        // If request is a `GET` to the `/` path, send to a named backend
         (&Method::GET, "/") => {
             // Request handling logic could go here...
-            // Such as send the request to an origin backend and then cache the
+            // Eg. send the request to an origin backend and then cache the
             // response for one minute.
             req.send("backend-name", ONE_MINUTE_TTL)
         }
-        // If request path starts with `/other/`.
+
+        // If request is a `GET` to a path starting with `/other/`.
         (&Method::GET, path) if path.starts_with("/other/") => {
             // Send request to a different backend and don't cache response.
             req.send("other-backend-name", NO_CACHE_TTL)
         }
+
         // Catch all other requests and return a 404.
-        _ => Ok(Response::builder()
+        _ => Ok(
+            Response::builder()
             .status(StatusCode::NOT_FOUND)
-            .body(Body::try_from("The page you requested could not be found")?)?),
+            .body(Body::try_from("The page you requested could not be found")?)?
+        ),
     }
 }
 
+/// The entrypoint for your application
+///
+/// This function is triggered when your service receives a client request, and
+/// should ultimately call `send_downstream` on a fastly::Response to deliver an
+/// HTTP response to the client.
 fn main() -> Result<(), Error> {
-    // Get the downstream request from the client.
     let req = downstream_request()?;
-    // Pass the request to the request handler and return a response.
-    let resp = handle_request(req)?;
-    // Send the response downstream to the client.
-    resp.send_downstream()?;
+    match handle_request(req) {
+        Ok(resp) => resp.send_downstream()?,
+        Err(e) => {
+            let mut resp = Response::new(Vec::from(e.msg));
+            *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+            resp.send_downstream()?;
+        }
+    }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use fastly::http::{Method, StatusCode, HeaderValue};
+use fastly::http::{HeaderValue, Method, StatusCode};
 use fastly::{downstream_request, Body, Error, Request, RequestExt, Response, ResponseExt};
 use std::convert::TryFrom;
 
@@ -12,19 +12,18 @@ const NO_CACHE_TTL: i32 = -1;
 /// send the request to a backend, make completely new requests and/or generate
 /// synthetic responses.
 fn handle_request(mut req: Request<Body>) -> Result<Response<Body>, Error> {
-
     // Make any desired changes to the client request
-    req.headers_mut().insert("Host", HeaderValue::from_static("example.com"));
+    req.headers_mut()
+        .insert("Host", HeaderValue::from_static("example.com"));
 
     // Pattern match on the request method and path.
     match (req.method(), req.uri().path()) {
-
         // If request method is not GET or HEAD, error
-        (method, _) if !(vec![Method::HEAD, Method::GET].contains(method)) => Ok(
-            Response::builder()
-            .status(StatusCode::METHOD_NOT_ALLOWED)
-            .body(Body::try_from("Only GET and HEAD requests are allowed")?)?
-        ),
+        (method, _) if !(vec![Method::HEAD, Method::GET].contains(method)) => {
+            Ok(Response::builder()
+                .status(StatusCode::METHOD_NOT_ALLOWED)
+                .body(Body::try_from("Only GET and HEAD requests are allowed")?)?)
+        }
 
         // If request is a `GET` to the `/` path, send to a named backend
         (&Method::GET, "/") => {
@@ -41,11 +40,9 @@ fn handle_request(mut req: Request<Body>) -> Result<Response<Body>, Error> {
         }
 
         // Catch all other requests and return a 404.
-        _ => Ok(
-            Response::builder()
+        _ => Ok(Response::builder()
             .status(StatusCode::NOT_FOUND)
-            .body(Body::try_from("The page you requested could not be found")?)?
-        ),
+            .body(Body::try_from("The page you requested could not be found")?)?),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn handle_request(mut req: Request<Body>) -> Result<Response<Body>, Error> {
         (method, _) if !(vec![Method::HEAD, Method::GET].contains(method)) => Ok(
             Response::builder()
             .status(StatusCode::METHOD_NOT_ALLOWED)
-            .body(Body::try_from("The page you requested could not be found")?)?
+            .body(Body::try_from("Only GET and HEAD requests are allowed")?)?
         ),
 
         // If request is a `GET` to the `/` path, send to a named backend

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn main() -> Result<(), Error> {
     match handle_request(req) {
         Ok(resp) => resp.send_downstream()?,
         Err(e) => {
-            let mut resp = Response::new(Vec::from(e.msg));
+            let mut resp = Response::new(e.msg.as_bytes());
             *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
             resp.send_downstream()?;
         }


### PR DESCRIPTION
* Mutating the client request is a common use case, so receive the client request in `handle_request` as mutable.
* Make an example mutation to the request (and also to avoid rust complaining that the `mut` is unnecessary)
* Add Jake's mechanism for passing runtime errors into the HTTP response
* Add a match arm for checking method against a list of allowed methods
* Some minor spacing and copy changes which (arguably) improve clarity