### PR TITLE
changes backend names to snake case [..]

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,13 +35,13 @@ fn handle_request(mut req: Request<Body>) -> Result<Response<Body>, Error> {
             // Request handling logic could go here...
             // Eg. send the request to an origin backend and then cache the
             // response for one minute.
-            req.send("backend-name", ONE_MINUTE_TTL)
+            req.send("backend_name", ONE_MINUTE_TTL)
         }
 
         // If request is a `GET` to a path starting with `/other/`.
         (&Method::GET, path) if path.starts_with("/other/") => {
             // Send request to a different backend and don't cache response.
-            req.send("other-backend-name", NO_CACHE_TTL)
+            req.send("other_backend_name", NO_CACHE_TTL)
         }
 
         // Catch all other requests and return a 404.


### PR DESCRIPTION
Changes backend names from kebab case to snake case. Otherwise, VCC errors
like the message bellow appear when running integration tests on this template.

```
###  17.380 p.v0 CMD: /opt/fst-varnish/bin/vcc -o /tmp/vtc.17497.6b8b4567/p.v0/service1.0.c  /tmp/vtc.17497.6b8b4567/p.v0/service1.0.vcl 2>&1
#### 17.397 p.v0 vcc| Syntax error: Expected identifier with characters [0-9a-zA-Z_] only\n
#### 17.397 p.v0 vcc| at: (input Line 2 Pos 9)\n
#### 17.397 p.v0 vcc| backend backend-name {\n
```