### PR TITLE
🦀 add additional code owners for rust files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 /README.md @fastly/developer-relations
 /fastly.toml @fastly/developer-relations
+*.rs @fastly/ecp-sdk-sme
+/Cargo.toml @fastly/ecp-sdk-sme


### PR DESCRIPTION
### 🦀 add additional code owners for rust files

Add additional code owners, to automatically request reviews from
C@E subject matter experts when changes to Rust files (or the
package manifest) are made.

See also fastly/fastly-template-rust-beacon-termination#6 which includes an identical change.