### PR TITLE
Add an 'allow' header to 405 method not allowed response.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ fn main(mut req: Request) -> Result<Response, Error> {
         // Deny anything else.
         _ => {
             return Ok(Response::from_status(StatusCode::METHOD_NOT_ALLOWED)
+                .with_header(header::ALLOW, "GET, HEAD")
                 .with_body_str("This method is not allowed\n"))
         }
     };


### PR DESCRIPTION
### TL;DR
Adds an `allow` header to the `405 Method not allowed` synthetic response to be spec compliant. This is my fault for not including when I wrote this originally.

Per spec [rfc7231](https://tools.ietf.org/html/rfc7231#section-6.5.5):
>   The 405 (Method Not Allowed) status code indicates that the method
   received in the request-line is known by the origin server but not
   supported by the target resource.  The origin server MUST generate an
   Allow header field in a 405 response containing a list of the target
   resource's currently supported methods.