### PR TITLE
Provide `[setup]` configuration

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -12,6 +12,6 @@ language = "rust"
     port = 443
   [[setup.backends]]
     name = "other_backend_name"
-    prompt = "Origin server able to serve /anything/ path (and change of Host header to example.com)"
+    prompt = "Origin server able to serve `/anything` path"
     address = "httpbin.org"
     port = 443

--- a/fastly.toml
+++ b/fastly.toml
@@ -7,7 +7,7 @@ language = "rust"
 [setup]
   [[setup.backends]]
     name = "backend_name"
-    prompt = "Origin server able to serve /solutions/ path"
+    prompt = "Origin server able to serve `/solutions/` path"
     address = "developer.fastly.com"
     port = 443
   [[setup.backends]]

--- a/fastly.toml
+++ b/fastly.toml
@@ -4,6 +4,9 @@ description = "Get to know the Fastly Compute@Edge environment with a basic star
 authors = ["<oss@fastly.com>"]
 language = "rust"
 
+# The [setup] section is used by the Fastly CLI to provide a more integrated experience for shared 'Starter Kits'.
+# https://developer.fastly.com/reference/fastly-toml/
+#
 [setup]
   [[setup.backends]]
     name = "backend_name"

--- a/fastly.toml
+++ b/fastly.toml
@@ -10,11 +10,11 @@ language = "rust"
 [setup]
   [[setup.backends]]
     name = "backend_name"
-    prompt = "Origin server able to serve `/solutions/` path"
+    prompt = "Backend able to serve `/solutions/` path"
     address = "developer.fastly.com"
     port = 443
   [[setup.backends]]
     name = "other_backend_name"
-    prompt = "Origin server able to serve `/anything` path"
+    prompt = "Backend able to serve `/anything` path"
     address = "httpbin.org"
     port = 443

--- a/fastly.toml
+++ b/fastly.toml
@@ -13,8 +13,10 @@ language = "rust"
     prompt = "Origin server able to serve `/solutions/` path"
     address = "developer.fastly.com"
     port = 443
+    override_host = "developer.fastly.com"
   [[setup.backends]]
     name = "other_backend_name"
     prompt = "Origin server able to serve `/anything` path"
     address = "httpbin.org"
     port = 443
+    override_host = "httpbin.org"

--- a/fastly.toml
+++ b/fastly.toml
@@ -13,10 +13,8 @@ language = "rust"
     prompt = "Origin server able to serve `/solutions/` path"
     address = "developer.fastly.com"
     port = 443
-    override_host = "developer.fastly.com"
   [[setup.backends]]
     name = "other_backend_name"
     prompt = "Origin server able to serve `/anything` path"
     address = "httpbin.org"
     port = 443
-    override_host = "httpbin.org"

--- a/fastly.toml
+++ b/fastly.toml
@@ -10,8 +10,8 @@ language = "rust"
 [setup]
   [[setup.backends]]
     name = "backend_name"
-    prompt = "Backend able to serve `/fastly` path"
-    address = "github.com"
+    prompt = "Backend able to serve `/articles` path"
+    address = "reqbin.com"
     port = 443
   [[setup.backends]]
     name = "other_backend_name"

--- a/fastly.toml
+++ b/fastly.toml
@@ -4,7 +4,7 @@ description = "Get to know the Fastly Compute@Edge environment with a basic star
 authors = ["<oss@fastly.com>"]
 language = "rust"
 
-# The [setup] section is used by the Fastly CLI to provide a more integrated experience for shared 'Starter Kits'.
+# The [setup] section is used by the Fastly CLI to provide a more integrated experience for shared Starter Kits.
 # https://developer.fastly.com/reference/fastly-toml/
 #
 [setup]

--- a/fastly.toml
+++ b/fastly.toml
@@ -12,6 +12,6 @@ language = "rust"
     port = 443
   [[setup.backends]]
     name = "other_backend_name"
-    prompt = "Origin server able to serve /anything/ path"
+    prompt = "Origin server able to serve /anything/ path (and change of Host header to example.com)"
     address = "httpbin.org"
     port = 443

--- a/fastly.toml
+++ b/fastly.toml
@@ -10,8 +10,8 @@ language = "rust"
 [setup]
   [[setup.backends]]
     name = "backend_name"
-    prompt = "Backend able to serve `/solutions/` path"
-    address = "developer.fastly.com"
+    prompt = "Backend able to serve `/fastly` path"
+    address = "github.com"
     port = 443
   [[setup.backends]]
     name = "other_backend_name"

--- a/fastly.toml
+++ b/fastly.toml
@@ -3,3 +3,15 @@ name = "Default starter for Rust"
 description = "Get to know the Fastly Compute@Edge environment with a basic starter kit that demonstrates routing, simple synthetic responses and overriding caching rules."
 authors = ["<oss@fastly.com>"]
 language = "rust"
+
+[setup]
+  [[setup.backends]]
+    name = "backend_name"
+    prompt = "Origin server able to serve /solutions/ path"
+    address = "developer.fastly.com"
+    port = 443
+  [[setup.backends]]
+    name = "other_backend_name"
+    prompt = "Origin server able to serve /anything/ path"
+    address = "httpbin.org"
+    port = 443

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,8 @@ fn main(mut req: Request) -> Result<Response, Error> {
             .with_content_type(mime::TEXT_HTML_UTF_8)
             .with_body("<iframe src='https://developer.fastly.com/compute-welcome' style='border:0; position: absolute; top: 0; left: 0; width: 100%; height: 100%'></iframe>\n")),
 
-        // If request is to the `/solutions/` path, send to a named backend.
-        "/solutions/" => {
+        // If request is to the `/fastly` path, send to a named backend.
+        "/fastly" => {
             // Request handling logic could go here...  E.g., send the request to an origin backend
             // and then cache the response for one minute.
             req.set_ttl(60);

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,9 +21,6 @@ const OTHER_BACKEND_NAME: &str = "other_backend_name";
 /// If `main` returns an error, a 500 error response will be delivered to the client.
 #[fastly::main]
 fn main(mut req: Request) -> Result<Response, Error> {
-    // Make any desired changes to the client request.
-    req.set_header(header::HOST, "example.com");
-
     // Filter request methods...
     match req.get_method() {
         // Allow GET and HEAD requests.
@@ -47,16 +44,19 @@ fn main(mut req: Request) -> Result<Response, Error> {
             .with_content_type(mime::TEXT_HTML_UTF_8)
             .with_body("<iframe src='https://developer.fastly.com/compute-welcome' style='border:0; position: absolute; top: 0; left: 0; width: 100%; height: 100%'></iframe>\n")),
 
-        // If request is to the `/backend` path, send to a named backend.
-        "/backend" => {
+        // If request is to the `/solutions/` path, send to a named backend.
+        "/solutions/" => {
             // Request handling logic could go here...  E.g., send the request to an origin backend
             // and then cache the response for one minute.
             req.set_ttl(60);
             Ok(req.send(BACKEND_NAME)?)
         }
 
-        // If request is to a path starting with `/other/`...
-        path if path.starts_with("/other/") => {
+        // If request is to a path starting with `/anything`...
+        path if path.starts_with("/anything") => {
+            // Make any desired changes to the client request.
+            req.set_header(header::HOST, "example.com");
+
             // Send request to a different backend and don't cache response.
             req.set_pass(true);
             Ok(req.send(OTHER_BACKEND_NAME)?)

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,8 @@ fn main(mut req: Request) -> Result<Response, Error> {
             .with_content_type(mime::TEXT_HTML_UTF_8)
             .with_body("<iframe src='https://developer.fastly.com/compute-welcome' style='border:0; position: absolute; top: 0; left: 0; width: 100%; height: 100%'></iframe>\n")),
 
-        // If request is to the `/fastly` path, send to a named backend.
-        "/fastly" => {
+        // If request is to the `/articles` path, send to a named backend.
+        "/articles" => {
             // Request handling logic could go here...  E.g., send the request to an origin backend
             // and then cache the response for one minute.
             req.set_ttl(60);

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ fn main(mut req: Request) -> Result<Response, Error> {
         // If request is to a path starting with `/anything`...
         path if path.starts_with("/anything") => {
             // Make any desired changes to the client request.
-            req.set_header(header::HOST, "example.com");
+            req.set_header("X-CustomExample", "foobar");
 
             // Send request to a different backend and don't cache response.
             req.set_pass(true);


### PR DESCRIPTION
This PR should be blocked until the CLI has the correlating support for `[setup]`.

**NOTE**: I've modified the Rust code slightly so that we could have a more practical 'default' example (e.g. the user just pulls the starter kit and wants to deploy it  "as is" to be sure the code and deployment works before they start making their own changes). 

Additionally, I've made the expectations (as far as the backends are concerned) very explicit in case a user sets their own backends but doesn't actually change the starter kit code in any way. At least they know what is required of the code for it to work when deployed.