### PR TITLE
Remove the debug = true release profile flag

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,2 @@
-[target.wasm32-wasi]
-rustflags = ["-C", "debuginfo=2"]
-
 [build]
 target = "wasm32-wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 publish = false
 
 [profile.release]
-debug = true
+debug = 1
 
 [dependencies]
 fastly = "^0.8.0"


### PR DESCRIPTION
### TL;DR
Removes the `-C debuginfo=2` rustc flag that we set on the `wasm32-wasi` targetm as its been found to slow down builds considerably and isn't really used for debugging and change the `profile.release` to `debug = 1`.

Related to: https://github.com/fastly/cli/pull/416