### PR TITLE
use latest `manifest_version` interface

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -8,10 +8,10 @@ language = "rust"
 # https://developer.fastly.com/reference/fastly-toml/
 #
 [setup.backends.backend_name]
-prompt = "Backend able to serve `/articles` path"
+description = "A backend able to serve `/articles` path"
 address = "reqbin.com"
 port = 443
 [setup.backends.other_backend_name]
-prompt = "Backend able to serve `/anything` path"
+description = "A backend able to serve `/anything` path"
 address = "httpbin.org"
 port = 443

--- a/fastly.toml
+++ b/fastly.toml
@@ -1,4 +1,4 @@
-manifest_version = 1
+manifest_version = 2
 name = "Default starter for Rust"
 description = "A basic starter kit that demonstrates routing, simple synthetic responses and overriding caching rules."
 authors = ["<oss@fastly.com>"]

--- a/fastly.toml
+++ b/fastly.toml
@@ -7,14 +7,11 @@ language = "rust"
 # The [setup] section is used by the Fastly CLI to provide a more integrated experience for shared Starter Kits.
 # https://developer.fastly.com/reference/fastly-toml/
 #
-[setup]
-  [[setup.backends]]
-    name = "backend_name"
-    prompt = "Backend able to serve `/articles` path"
-    address = "reqbin.com"
-    port = 443
-  [[setup.backends]]
-    name = "other_backend_name"
-    prompt = "Backend able to serve `/anything` path"
-    address = "httpbin.org"
-    port = 443
+[setup.backends.backend_name]
+prompt = "Backend able to serve `/articles` path"
+address = "reqbin.com"
+port = 443
+[setup.backends.other_backend_name]
+prompt = "Backend able to serve `/anything` path"
+address = "httpbin.org"
+port = 443


### PR DESCRIPTION
The https://developer.fastly.com/reference/compute/fastly-toml/ reference is being updated with a breaking change to the `[setup]` configuration. This change will result in a bump in `manifest_version` to version `2`. 

The next CLI release (`v0.39.3`) will only support manifests with a version number of `2`. So it's important that we coordinate the update to the fastly.toml documentation, and also each of the starter kits that the CLI references, so they specify their manifest_version as being version `2` (hence this PR).