### PR TITLE
remove build scripts from fastly.toml

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -6,7 +6,3 @@ description = "A basic starter kit that demonstrates routing, simple synthetic r
 language = "rust"
 manifest_version = 2
 name = "Default starter for Rust"
-service_id = ""
-
-[scripts]
-  build = "cargo build --bin fastly-compute-project --release --target wasm32-wasi --color always"


### PR DESCRIPTION
Context: https://github.com/fastly/compute-starter-kit-rust-static-content/pull/22#discussion_r1088904863