### PR TITLE
Journie adding version logging

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -6,7 +6,3 @@ description = "A basic starter kit that demonstrates routing, simple synthetic r
 language = "rust"
 manifest_version = 2
 name = "Default starter for Rust"
-service_id = ""
-
-[scripts]
-  build = "cargo build --bin fastly-compute-project --release --target wasm32-wasi --color always"

--- a/fastly.toml
+++ b/fastly.toml
@@ -6,3 +6,7 @@ description = "A basic starter kit that demonstrates routing, simple synthetic r
 language = "rust"
 manifest_version = 2
 name = "Default starter for Rust"
+service_id = ""
+
+[scripts]
+  build = "cargo build --bin fastly-compute-project --release --target wasm32-wasi --color always"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use fastly::{mime, Error, Request, Response};
 
 #[fastly::main]
 fn main(req: Request) -> Result<Response, Error> {
+    println!("FASTLY_SERVICE_VERSION: {}", std::env::var("FASTLY_SERVICE_VERSION").unwrap_or_else(|_| String::new()));
     // Filter request methods...
     match req.get_method() {
         // Allow GET and HEAD requests.

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use fastly::{mime, Error, Request, Response};
 
 #[fastly::main]
 fn main(req: Request) -> Result<Response, Error> {
-    //Log service version
+    // Log service version
     println!("FASTLY_SERVICE_VERSION: {}", std::env::var("FASTLY_SERVICE_VERSION").unwrap_or_else(|_| String::new()));
     // Filter request methods...
     match req.get_method() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use fastly::{mime, Error, Request, Response};
 
 #[fastly::main]
 fn main(req: Request) -> Result<Response, Error> {
+    //Log service version
     println!("FASTLY_SERVICE_VERSION: {}", std::env::var("FASTLY_SERVICE_VERSION").unwrap_or_else(|_| String::new()));
     // Filter request methods...
     match req.get_method() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,11 @@ use fastly::{mime, Error, Request, Response};
 #[fastly::main]
 fn main(req: Request) -> Result<Response, Error> {
     // Log service version
-    println!("FASTLY_SERVICE_VERSION: {}", std::env::var("FASTLY_SERVICE_VERSION").unwrap_or_else(|_| String::new()));
+    println!(
+        "FASTLY_SERVICE_VERSION: {}",
+        std::env::var("FASTLY_SERVICE_VERSION").unwrap_or_else(|_| String::new())
+    );
+    
     // Filter request methods...
     match req.get_method() {
         // Allow GET and HEAD requests.


### PR DESCRIPTION
Prints the service version to the console after running `fastly log-tail`.  ([JIRA ticket](https://fastly.atlassian.net/browse/DEVLIB-856?atlOrigin=eyJpIjoiMDY0MmI0YThjZDVhNGE5NjljZjBiZGNjNTkzOWY2NDMiLCJwIjoiaiJ9))