### PR TITLE
Populate scripts.build

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -6,3 +6,6 @@ description = "A basic starter kit that demonstrates routing, simple synthetic r
 language = "rust"
 manifest_version = 3
 name = "Default starter for Rust"
+
+[scripts]
+  build = "cargo build --bin fastly-compute-project --release --target wasm32-wasi --color always"


### PR DESCRIPTION
For backwards compatibility Fastly CLI implies a `scripts.build` based on the language, but it's best to provide one in the `fastly.toml`.